### PR TITLE
Fix for items not being retired in non-incremental feeds

### DIFF
--- a/syndicatedlink.class.php
+++ b/syndicatedlink.class.php
@@ -268,6 +268,7 @@ class SyndicatedLink {
 				'ignore_sticky_posts' => true,
 				'meta_key' => 'syndication_feed_id',
 				'meta_value' => $this->id,
+				'posts_per_page' => -1
 				));
 				foreach ($q->posts as $p) :
 					update_post_meta($p->ID, '_feedwordpress_retire_me_'.$this->id, '1');
@@ -374,6 +375,7 @@ class SyndicatedLink {
 		'ignore_sticky_posts' => true,
 		'meta_key' => '_feedwordpress_retire_me_'.$this->id,
 		'meta_value' => '1',
+		'posts_per_page' => -1
 		));
 		if ($q->have_posts()) :
 			foreach ($q->posts as $p) :


### PR DESCRIPTION
`WP_Query` was used to query WP posts to mark them for retirement or process retirements. `'posts_per_page'` query parameter was not specified so the default value was used (from **Settings**->**Reading** in WP admin), so only few first posts were retired, even though the feed might have more items removed from it.

I have only used the plugin with non-incremental feeds for now so can't comment on the behavior in different type of feeds. It's possible that there are more occurrences of `WP_Query` being used in similar fashion - these are not fixed.
